### PR TITLE
Remove mention of self-managed/OSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ If you've completed the initial setup, continue to [Universal Profiling features
 ## Get started with Universal Profiling
 
 At the moment, Universal Profiling is **only available on [Elastic Cloud](http://cloud.elastic.co)**.
-Eventually, it may also be available on self-managed or open-source distributions of the Elastic stack.
 
 Enabling Universal Profiling on a deployment currently requires some manual actions. Many of these actions will be
 automated in upcoming releases.


### PR DESCRIPTION
I would propose removing this line for two reasons: 

1. Saying it may be available invites the question of "when", and I  would rather have people in the mode of being pleasantly surprised
 when it does happen, instead of waiting impatiently. 
2. I am not sure what we mean by "self-managed OR open-source  versions", and I don't really want to get into a discussion with  customers over what "open source" will mean.