### PR TITLE
Simplify onboarding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ export ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
 - Get your deployment's APM Cluster ID from the deployment overview page and use it as `<APM_CLUSTER_ID>`.
 - Please use real values instead of the placeholders, e.g. replace `<ES_USER>` with `elastic`.
 
+The environment variables can be overridden by command line arguments, for details run `./elastic-profiling config --help`.
+
 ### Deployment configuration example
 
 The following deployment configuration example was tested to support profiling data from a fleet of up to 500 hosts, each with 8 or 16 CPU cores, for a total of roughly 6000 cores:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ at the end of this documentation for more information.
 Before setting up Universal Profiling, make sure you meet the following requirements:
 
 - An Elastic stack deployment on [Elastic Cloud](http://cloud.elastic.co) at version 8.5.0 or higher (you can either provision a new one or upgrade an existing one). Universal Profiling is currently only available on Elastic Cloud.
-- The Integrations Server must be enabled on your deployment.
+- The Integrations Server must be enabled on your Elastic Cloud deployment.
 - Credentials (either an API key or username and password) for the `superuser` Elasticsearch role (typically, the `elastic` user).
 - An x86_64 Linux machine with a terminal to run commands.
 - The deployment's Cloud ID from the deployment overview page.

--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ The minimum supported versions of interpreters are:
 
 ### Preparation
 
-Create a text file with the following content and name it `config.txt` for later reference:
+Prepare a configuration file `config.txt` with the following command, using the values from your deployment instead of the placeholders:
 ```
+cat <<EOF > config.txt
 export ES_USER=<ES_USER>
 export ES_PASSWORD=<ES_PASSWORD>
 export ES_CLOUD_ID=<CLOUD_ID>
 export ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
+EOF
 ```
+This file will be used to run commands later on.
+
 - Use the `superuser` Elasticsearch credentials for `<ES_USERNAME>` and `<ES_PASSWORD>`.
 - Get the deployment's Cloud ID from the deployment overview page and use it as `<CLOUD_ID>`.
 - Get your deployment's APM Cluster ID from the deployment overview page and use it as `<APM_CLUSTER_ID>`.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ at the end of this documentation for more information.
 Before setting up Universal Profiling, make sure you meet the following requirements:
 
 - An Elastic stack deployment on [Elastic Cloud](http://cloud.elastic.co) at version 8.5.0 or higher (you can either provision a new one or upgrade an existing one). Universal Profiling is currently only available on Elastic Cloud.
-- The Integrations Server must be enabled on your Elastic Cloud deployment.
+- The Integrations Server must be enabled on your deployment.
 - Credentials (either an API key or username and password) for the `superuser` Elasticsearch role (typically, the `elastic` user).
 - An x86_64 Linux machine with a terminal to run commands.
+- The deployment's Cloud ID from the deployment overview page.
+    ![cloud ID](./img/cloud-id.png)
+- The deployment's APM Cluster ID from the deployment overview page.
+   ![apm cluster ID](./img/apm-cluster-id.png)
 
 ### Interpreters
 
@@ -33,24 +37,19 @@ The minimum supported versions of interpreters are:
 - PHP: >= 7.3 
 - Ruby: >= 2.5 
 
-### Recommended deployment configuration
+### Preparation
 
-Before creating a new cluster or upgrading an existing one, review the suggested configuration for each Elastic Stack component.
-
-As a preparation step, create a text file with the following content (let's name it `config.txt` for later reference):
+Create a text file with the following content and name it `config.txt` for later reference:
 ```
 export ES_USER=<ES_USER>
 export ES_PASSWORD=<ES_PASSWORD>
 export ES_CLOUD_ID=<CLOUD_ID>
 export ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
 ```
-Use the `superuser` Elasticsearch credentials for `<ES_USERNAME>` and `<ES_PASSWORD>`.
-
-Get the deployment's Cloud ID from the deployment overview page and use it as `<CLOUD_ID>`.
-    ![cloud ID](./img/cloud-id.png)
-
-Get your deployment's APM Cluster ID from the deployment overview page and use it as `<APM_CLUSTER_ID>`.
-   ![apm cluster ID](./img/apm-cluster-id.png)
+- Use the `superuser` Elasticsearch credentials for `<ES_USERNAME>` and `<ES_PASSWORD>`.
+- Get the deployment's Cloud ID from the deployment overview page and use it as `<CLOUD_ID>`.
+- Get your deployment's APM Cluster ID from the deployment overview page and use it as `<APM_CLUSTER_ID>`.
+- Please use real values instead of the placeholders, e.g. replace `<ES_USER>` with `elastic`.
 
 ### Deployment configuration example
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ export ES_USER=<ES_USER>
 export ES_PASSWORD=<ES_PASSWORD>
 export ES_CLOUD_ID=<CLOUD_ID>
 export ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
+export KB_USER=<KB_USER>
+export KB_PASSWORD=<KB_PASSWORD>
 ```
 Use the `superuser` Elasticsearch credentials for `<ES_USERNAME>` and `<ES_PASSWORD>`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before creating a new cluster or upgrading an existing one, review the suggested
 
 As a preparation step, create a text file with the following content (let's name it `config.txt` for later reference):
 ```
-ES_USERNAME=<ES_USERNAME>
+ES_USER=<ES_USER>
 ES_PASSWORD=<ES_PASSWORD>
 ES_CLOUD_ID=<CLOUD_ID>
 ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ export ES_USER=<ES_USER>
 export ES_PASSWORD=<ES_PASSWORD>
 export ES_CLOUD_ID=<CLOUD_ID>
 export ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
-export KB_USER=<KB_USER>
-export KB_PASSWORD=<KB_PASSWORD>
 ```
 Use the `superuser` Elasticsearch credentials for `<ES_USERNAME>` and `<ES_PASSWORD>`.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To configure data ingestion:
   
 1. Set up Universal Profiling in your deployment.
    ```
-   . config.txt
+   source config.txt
    ./elastic-profiling setup cloud --reset
    ```
 1. Confirm that this is the first time setting up Universal Profiling in the terminal prompt.
@@ -131,7 +131,7 @@ To complete the basic setup of a host-agent on your Linux machine:
 
 1. Print the `binary` configuration to test it on your current Linux machine by running:
    ```bash
-   . config.txt
+   source config.txt
    ./elastic-profiling config --binary
    ```
 1. Run the host-agent with the provided steps, testing that your Universal Profiling deployment is working as expected.
@@ -203,7 +203,7 @@ No additional parameters need to be passed during the build. To push symbols for
 invoke the `elastic-profiling` tool:
 
 ```
-. config.txt
+source config.txt
 ./elastic-profiling push-symbols executable -e ./my-go-app 
 ```
 
@@ -218,7 +218,7 @@ production, but needs to be present temporarily to push them to the Elastic clus
 If you don't mind deploying your applications with debug symbols, run:
 
 ```
-. config.txt
+source config.txt
 ./elastic-profiling push-symbols executable -e ./my-c-app 
 ```
 
@@ -230,7 +230,7 @@ the symbols have been pushed, you can remove the unstripped binary:
 ```
 cp ./my-app ./my-stripped-app
 strip ./my-stripped-app
-. config.txt
+source config.txt
 ./elastic-profiling push-symbols executable -e ./my-stripped-app -d ./my-app
 rm ./my-app
 ```
@@ -261,14 +261,14 @@ For this to work, make sure that the debuginfod client is installed on your mach
 Then, invoke `elastic-profiling` as follows:
 
 ```
-. config.txt
+source config.txt
 ./elastic-profiling push-symbols package -p package-name
 ```
 
 For example, to push symbols for libc on Debian:
 
 ```
-. config.txt
+source config.txt
 ./elastic-profiling push-symbols package -p libc6
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Before creating a new cluster or upgrading an existing one, review the suggested
 
 As a preparation step, create a text file with the following content (let's name it `config.txt` for later reference):
 ```
-ES_USER=<ES_USER>
-ES_PASSWORD=<ES_PASSWORD>
-ES_CLOUD_ID=<CLOUD_ID>
-ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
+export ES_USER=<ES_USER>
+export ES_PASSWORD=<ES_PASSWORD>
+export ES_CLOUD_ID=<CLOUD_ID>
+export ES_APM_CLUSTER_ID=<APM_CLUSTER_ID>
 ```
 Use the `superuser` Elasticsearch credentials for `<ES_USERNAME>` and `<ES_PASSWORD>`.
 


### PR DESCRIPTION
This is just a suggestion (thus keeping it in draft state for now) to simplify onboarding.

It simplifies the onboarding instructions around the `elastic-profiling` command lines.

I had participated in three onboarding sessions for now and each time there was some struggle to copy&paste the cloud_id, apm-cluster-id, username and password from here to there. I think this can be simplified.

To make it actually work, we need a small change in `elastic-profiling` as well: reading the environment variables before parsing the command line.
See https://github.com/elastic/prodfiler/pull/2822

Fixes https://github.com/elastic/prodfiler/issues/2819